### PR TITLE
Fix incorrect variable name in readme sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ func middleware() func(next http.Handler) http.Handler {
 	audience := "YOUR_API_NAME"
 
 	secretProvider := oidc.NewOidcSecretProvider(discovery.NewClient(discovery.Options{authority}))
-	validator := oidc.NewJWTValidator(jwtRequest.OAuth2Extractor, opts.SecretProvider, audience, authority)
+	validator := oidc.NewJWTValidator(jwtRequest.OAuth2Extractor, secretProvider, audience, authority)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
This corrects a tiny typo in the sample contained in the README.md file.

I'm not 100% that this is correct but when using the sample it helped for me.